### PR TITLE
Log exception details when mapping messages from SQS fails

### DIFF
--- a/synapse-aws-sqs/src/main/java/de/otto/synapse/endpoint/receiver/sqs/SqsMessageQueueReceiverEndpoint.java
+++ b/synapse-aws-sqs/src/main/java/de/otto/synapse/endpoint/receiver/sqs/SqsMessageQueueReceiverEndpoint.java
@@ -134,7 +134,7 @@ public class SqsMessageQueueReceiverEndpoint extends AbstractMessageReceiverEndp
             }
             deleteMessage(sqsMessage);
         } catch (final Exception e) {
-            LOG.error("Failed to process SQS message " + sqsMessage);
+            LOG.error("Failed to process SQS message " + sqsMessage, e);
         }
     }
 


### PR DESCRIPTION
We're currently finding error logs in our application, but it's hard to pinpoint the exact cause because the stacktrace of the exception is missing. This change would allow to analyse any mapping error more effectively.