### PR TITLE
fixes key generation on null key in kafka consumer record

### DIFF
--- a/synapse-kafka/src/main/java/de/otto/synapse/endpoint/receiver/kafka/ChannelDurationBehindHandler.java
+++ b/synapse-kafka/src/main/java/de/otto/synapse/endpoint/receiver/kafka/ChannelDurationBehindHandler.java
@@ -66,6 +66,7 @@ class ChannelDurationBehindHandler implements ConsumerRebalanceListener {
         channelDurationBehind.updateAndGet(behind -> copyOf(behind)
                 .with(shardName, durationBehind)
                 .build());
+        LOG.info("Read from '{}:{}', durationBehind={}",  channelName, shardName, durationBehind);
 
         if (eventPublisher != null) {
             eventPublisher.publishEvent(builder()

--- a/synapse-kafka/src/main/java/de/otto/synapse/endpoint/receiver/kafka/KafkaDecoder.java
+++ b/synapse-kafka/src/main/java/de/otto/synapse/endpoint/receiver/kafka/KafkaDecoder.java
@@ -8,6 +8,8 @@ import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.Headers;
 import org.slf4j.Logger;
 
+import java.util.UUID;
+
 import static de.otto.synapse.channel.ShardPosition.fromPosition;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.slf4j.LoggerFactory.getLogger;
@@ -36,6 +38,8 @@ public class KafkaDecoder implements Decoder<ConsumerRecord<String, String>> {
 
         if (partitionKey != null && compactionKey != null && compactionKey.equals(record.key())) {
             key = Key.of(partitionKey, compactionKey);
+        } else if (record.key() == null) {
+            key = Key.of(UUID.randomUUID().toString());
         } else {
             key = Key.of(record.key());
         }

--- a/synapse-kafka/src/test/java/de/otto/synapse/endpoint/receiver/kafka/KafkaDecoderTest.java
+++ b/synapse-kafka/src/test/java/de/otto/synapse/endpoint/receiver/kafka/KafkaDecoderTest.java
@@ -15,7 +15,7 @@ import static de.otto.synapse.channel.ShardPosition.fromPosition;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Arrays.asList;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.*;
 
 public class KafkaDecoderTest {
 
@@ -36,6 +36,26 @@ public class KafkaDecoderTest {
 
         // then
         assertThat(decodedMessage.getKey().compactionKey(), is("key"));
+        assertThat(decodedMessage.getPayload(), is("payload"));
+    }
+
+    @Test
+    public void shouldDecodeMessageWithNullKey() {
+        // given
+        final KafkaDecoder decoder = new KafkaDecoder();
+        final ConsumerRecord<String,String> record = new ConsumerRecord<>(
+                "ch01",
+                0,
+                42L,
+                null,
+                "payload"
+        );
+
+        // when
+        TextMessage decodedMessage = decoder.apply(record);
+
+        // then
+        assertThat(decodedMessage.getKey().compactionKey(), notNullValue());
         assertThat(decodedMessage.getPayload(), is("payload"));
     }
 


### PR DESCRIPTION
when a plain text message is added like the follwing:
```
./kafka_2.12-2.5.0/bin/kafka-console-producer.sh --bootstrap-server localhost:9092 --topic some-topic
hallo
```
an NPE is caused in the KafkaDecoder as it assumes that the Record always has a value, which is may not have:
https://kafka.apache.org/11/javadoc/org/apache/kafka/clients/producer/ProducerRecord.html#key--