### PR TITLE
Update Spring to 5.3.18 which fixes CVE-2022-22965 aka "Spring4shell"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ buildscript {
 
 ext {
     awsSdkVersion = "2.17.157"
-    springVersion = "5.3.17"
+    springVersion = "5.3.18"
     springSecurityVersion = "5.6.2"
     springBootVersion = "2.6.5"
     edisonVersion = "2.6.6"


### PR DESCRIPTION
See details: https://tanzu.vmware.com/security/cve-2022-22965